### PR TITLE
spruce up the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Cog example models
 
-These are some models you can use to try out [Cog](https://github.com/replicate/cog).
+This repo contains example machine learning models you can use to try out [Cog](https://github.com/replicate/cog).
+
+Once you've got a working model and want to publish it so others can see it in action, check out [replicate.com/docs](https://replicate.com/docs)
+
+## Support
+
+Having trouble getting a model working? Let us know and we'll help. If you encountered a problem with Cog, you can [file a GitHub issue](https://github.com/replicate/cog/issues). Otherwise [chat with us in Discord](https://discord.gg/replicate) or send us an email at [team@replicate.com](mailto:team@replicate.com).
+
+
+## Real World Examples
 
 The models in this repo are small and contrived. Here are a few real-world examples:
+
 * https://github.com/andreasjansson/pretrained-gan-70s-scifi
 * https://github.com/andreasjansson/sota-music-tagging-models
 * https://github.com/andreasjansson/StyleCLIP

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 This repo contains example machine learning models you can use to try out [Cog](https://github.com/replicate/cog).
 
-Once you've got a working model and want to publish it so others can see it in action, check out [replicate.com/docs](https://replicate.com/docs)
+Once you've got a working model and want to publish it so others can see it in action, check out [replicate.com/docs](https://replicate.com/docs).
 
 ## Support
 
 Having trouble getting a model working? Let us know and we'll help. If you encountered a problem with Cog, you can [file a GitHub issue](https://github.com/replicate/cog/issues). Otherwise [chat with us in Discord](https://discord.gg/replicate) or send us an email at [team@replicate.com](mailto:team@replicate.com).
-
 
 ## Real World Examples
 


### PR DESCRIPTION
@preeth1 pointed out today that the current README is a bit misleading if you gloss over it quickly... the links could be misinterpreted as the examples, when in fact they are separate real-world examples off in other repos.

This PR takes a shot at clarifying the README a bit, and adds some links so folks know how to get a hold of us for support.